### PR TITLE
Fixed btoa window error 

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1,86 +1,91 @@
 import React, { memo, useEffect, useState } from 'react';
 
 interface Props {
-    source: any
-    width?: number | string
-    height?: number | string
-    fill?: string
-    replace: any
-    className?: string
+  source: any;
+  width?: number | string;
+  height?: number | string;
+  fill?: string;
+  replace: any;
+  className?: string;
 }
 
-const regBase64 = /^(.+)\,(.+)$/
-const regPropReplace = /^\s*\{\s*([a-zA-Z0-9]*)\.?([a-zA-Z0-9]+)\s*\}\s*$/
+const regBase64 = /^(.+)\,(.+)$/;
+const regPropReplace = /^\s*\{\s*([a-zA-Z0-9]*)\.?([a-zA-Z0-9]+)\s*\}\s*$/;
 
 const Index = memo(({ source: orsource, replace, ...rest }: Props) => {
+  const { width, height, className } = {
+    width: 'auto',
+    height: 'auto',
+    ...rest,
+  };
 
-    const { width, height, className } = {
-        width: 'auto',
-        height: 'auto',
-        ...rest,
+  const [xml, setXml] = useState('');
+  const [source, setSource] = useState('');
+
+  const xmlToBase64 = (xml: string) => {
+    let nxml = xml;
+
+    for (const key in replace) {
+      let value = replace[key];
+
+      if (regPropReplace.test(value)) {
+        value = rest[value.replace(regPropReplace, '$2')];
+
+        if (value == undefined) break;
+      }
+
+      nxml = nxml.replace(
+        new RegExp(`([a-z-A-Z0-9\-\_]+="|')(${key})("|')`, 'g'),
+        `$1${value}$3`
+      );
     }
 
-    const [xml, setXml] = useState(null)
-    const [source, setSource] = useState(null)
+    return `data:image/svg+xml;base64,${btoa(
+      unescape(encodeURIComponent(nxml))
+    )}`;
+  };
 
-    const xmlToBase64 = (xml: string) => {
+  useEffect(() => {
+    if (!source) {
+      if (orsource instanceof String) {
+        setSource(orsource as string);
+      } else {
+        orsource.then((source: any) => setSource(source.default));
+      }
+    } else {
+      const ab = new AbortController();
 
-        let nxml = xml;
+      if (regBase64.test(source)) {
+        setXml(atob(source.replace(regBase64, '$2')));
+      } else {
+        fetch(source, { signal: ab.signal })
+          .then((res) => res.text())
+          .then((xml) => setXml(xml))
+          .catch((e) => console.error(e));
+      }
 
-        for (const key in replace) {
-
-            let value = replace[key]
-
-            if (regPropReplace.test(value)) {
-
-                value = rest[value.replace(regPropReplace, '$2')]
-
-                if (value == undefined) break;
-            }
-
-            nxml = nxml.replace(
-                new RegExp(`([a-z-A-Z0-9\-\_]+="|')(${key})("|')`, 'g')
-                , `$1${value}$3`
-            )
-        }
-
-        return `data:image/svg+xml;base64,${btoa(nxml)}`
+      return () => {
+        ab.abort();
+      };
     }
+  }, [source]);
 
-    useEffect(() => {
-
-        if (!source) {
-            if (orsource instanceof String) {
-                setSource(orsource)
-            } else {
-                orsource.then((source: any) => setSource(source.default))
-            }
-        } else {
-
-            const ab = new AbortController()
-
-            if (regBase64.test(source)) {
-                setXml(atob(source.replace(regBase64, '$2')))
-            } else {
-                fetch(source, { signal: ab.signal })
-                    .then(res => res.text())
-                    .then(xml => setXml(xml))
-                    .catch(e => console.error(e))
-            }
-
-            return () => { ab.abort() }
-        }
-
-    }, [source])
-
-    return xml ? <img className={className} width={width} height={height} src={xmlToBase64(xml)} /> : null
-})
+  return xml ? (
+    <img
+      className={className}
+      width={width}
+      height={height}
+      src={xmlToBase64(xml)}
+    />
+  ) : null;
+});
 
 export default (svgrrc: any) => {
+  const { replaceAttrValues } = svgrrc;
 
-    const { replaceAttrValues } = svgrrc
-
-    return (source: string) => {
-        return (props: any) => <Index {...props} replace={replaceAttrValues} source={source} />;
-    }
-}
+  return (source: string) => {
+    return (props: any) => (
+      <Index {...props} replace={replaceAttrValues} source={source} />
+    );
+  };
+};

--- a/loader/index.js
+++ b/loader/index.js
@@ -2,8 +2,8 @@ const fs = require('fs');
 const path = require('path');
 
 module.exports = function (source) {
-
-  const reg = /import\s+([0-9a-zA-Z\_\$]+)\s+from\s+("|')([^\s\n\;\'\"]+\.svg)("|')/g;
+  const reg =
+    /import\s+([0-9a-zA-Z\_\$]+)\s+from\s+("|')([^\s\n\;\'\"]+\.svg)("|')/g;
   const repl = `
   const $1 = __ReactNativeSvgLoader(import($2$3$4));
   `;
@@ -11,20 +11,19 @@ module.exports = function (source) {
   let js = source;
 
   if (reg.test(js)) {
-
     let svgrrc = '{}';
 
     try {
       svgrrc = fs.readFileSync(path.resolve(__dirname, '../../../.svgrrc'));
     } catch (error) {
-      console.warn(".svgrrc file not exists.");
+      console.warn('.svgrrc file not exists.');
     }
 
-    js = (`
+    js = `
        const __ReactNativeSvgLoader = require('react-native-svg-transformer-fix-expo').default(${svgrrc});
         ${js}
-        `).replace(reg, repl);
+        `.replace(reg, repl);
   }
 
   return js;
-}
+};


### PR DESCRIPTION
# Fixed Failed to execute 'btoa' on 'Window': The string to be encoded
Some SVG gave the following error:

![Screenshot from 2022-10-13 06-46-45](https://user-images.githubusercontent.com/52983571/195993669-dc5c88d3-79e6-4ea4-9120-63531db8b97f.png)

## Solution:
The following line was changed in index.tsx
```typescript
 return `data:image/svg+xml;base64,${btoa(nxml)}`
```
**by this:**
```typescript
 return `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(nxml)))}`
```